### PR TITLE
[sc-28126] Support application/didcomm-plain+json content type

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/getkin/kin-openapi v0.61.0 h1:6awGqF5nG5zkVpMsAih1QH4VgzS8phTxECUWIFo7zko=
-github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.80.0 h1:W/s5/DNnDCR8P+pYyafEWlGk4S7/AfQUWXgrRSSAzf8=
 github.com/getkin/kin-openapi v0.80.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -433,7 +433,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 		// handle application/json media types here. Other responses should
 		// simply be specified as strings or byte arrays.
 		response := responseOrRef.Value
-		jsonResponse, found := response.Content["application/json"]
+		jsonResponse, found := GetJsonMediaType(response.Content)
 		if found {
 			goType, err := GenerateGoSchema(jsonResponse.Schema, []string{responseName})
 			if err != nil {
@@ -471,7 +471,7 @@ func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*open
 		// As for responses, we will only generate Go code for JSON bodies,
 		// the other body formats are up to the user.
 		response := bodyOrRef.Value
-		jsonBody, found := response.Content["application/json"]
+		jsonBody, found := GetJsonMediaType(response.Content)
 		if found {
 			goType, err := GenerateGoSchema(jsonBody.Schema, []string{bodyName})
 			if err != nil {

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -163,7 +163,7 @@ type GetTestByNameResponse struct {
 	assert.Contains(t, code, "Top *int `json:\"$top,omitempty\"`")
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*GetTestByNameResponse, error) {")
-	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\"`")
+	assert.Contains(t, code, "DeadSince *time.Time     `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\"`")
 
 	// Make sure the generated code is valid:
 	linter := new(lint.Linter)
@@ -211,7 +211,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Test'
-            application/json:
+            application/didcomm-plain+json:
               schema:
                 type: array
                 items:

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -153,6 +153,16 @@ type GetTestByNameResponse struct {
 	JSONDefault  *Error
 }`)
 
+	// Check that types for the application/didcomm-plaintext+json were generated.
+	assert.Contains(t, code, `
+type CreateTestByNameResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]Test
+}`)
+	assert.Contains(t, code, "type CreateTestByNameJSONBody Test")
+	assert.Contains(t, code, "type CreateTestByNameJSONRequestBody CreateTestByNameJSONBody")
+
 	// Check that the helper methods are generated correctly:
 	assert.Contains(t, code, "func (r GetTestByNameResponse) Status() string {")
 	assert.Contains(t, code, "func (r GetTestByNameResponse) StatusCode() int {")

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -186,17 +186,36 @@ servers:
 
 paths:
   /test/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      tags:
+      - test
+      summary: Get test
+      operationId: createTestByName
+      requestBody:
+        content:
+          application/didcomm-plain+json:
+            schema:
+              $ref: '#/components/schemas/Test'
+      responses:
+        200:
+          content:
+            application/didcomm-plain+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Test'
     get:
       tags:
       - test
       summary: Get test
       operationId: getTestByName
       parameters:
-      - name: name
-        in: path
-        required: true
-        schema:
-          type: string
       - name: $top
         in: query
         required: false

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -54,8 +54,11 @@ func (pd *ParameterDefinition) JsonTag() string {
 func (pd *ParameterDefinition) IsJson() bool {
 	p := pd.Spec
 	if len(p.Content) == 1 {
-		_, found := p.Content["application/json"]
-		return found
+		for k := range p.Content {
+			if IsMediaTypeJson(k) {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -508,8 +511,8 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 		var tag string
 		var defaultBody bool
 
-		switch contentType {
-		case "application/json":
+		switch {
+		case IsMediaTypeJson(contentType):
 			tag = "JSON"
 			defaultBody = true
 		default:

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -100,12 +100,13 @@ type Constants struct {
 //
 // Let's use this example schema:
 // components:
-//  schemas:
-//    Person:
-//      type: object
-//      properties:
-//      name:
-//        type: string
+//
+//	schemas:
+//	  Person:
+//	    type: object
+//	    properties:
+//	    name:
+//	      type: string
 type TypeDefinition struct {
 	// The name of the type, eg, type <...> Person
 	TypeName string
@@ -614,7 +615,7 @@ func paramToGoType(param *openapi3.Parameter, path []string) (Schema, error) {
 	}
 
 	// Otherwise, look for application/json in there
-	mt, found := param.Content["application/json"]
+	mt, found := GetJsonMediaType(param.Content)
 	if !found {
 		// If we don't have json, it's a string
 		return Schema{

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	contentTypesJSON = []string{echo.MIMEApplicationJSON, "text/x-json"}
+	contentTypesJSON = []string{echo.MIMEApplicationJSON, "text/x-json", "application/didcomm-plain+json"}
 	contentTypesYAML = []string{"application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml"}
 	contentTypesXML  = []string{echo.MIMEApplicationXML, echo.MIMETextXML}
 )

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -251,7 +251,6 @@ func refPathToGoType(refPath string, local bool) (string, error) {
 // ./local/file.yml#/components/parameters/Bar  -> true
 // ./local/file.yml                             -> false
 // The function can be used to check whether RefPathToGoType($ref) is possible.
-//
 func IsGoTypeReference(ref string) bool {
 	return ref != "" && !IsWholeDocumentReference(ref)
 }
@@ -262,7 +261,6 @@ func IsGoTypeReference(ref string) bool {
 // ./local/file.yml                                     -> true
 // http://deepmap.com/schemas/document.json             -> true
 // http://deepmap.com/schemas/document.json#/Foo        -> false
-//
 func IsWholeDocumentReference(ref string) bool {
 	return ref != "" && !strings.ContainsAny(ref, "#")
 }
@@ -270,14 +268,15 @@ func IsWholeDocumentReference(ref string) bool {
 // This function converts a swagger style path URI with parameters to a
 // Echo compatible path URI. We need to replace all of Swagger parameters with
 // ":param". Valid input parameters are:
-//   {param}
-//   {param*}
-//   {.param}
-//   {.param*}
-//   {;param}
-//   {;param*}
-//   {?param}
-//   {?param*}
+//
+//	{param}
+//	{param*}
+//	{.param}
+//	{.param*}
+//	{;param}
+//	{;param*}
+//	{?param}
+//	{?param*}
 func SwaggerUriToEchoUri(uri string) string {
 	return pathParamRE.ReplaceAllString(uri, ":$1")
 }
@@ -285,14 +284,15 @@ func SwaggerUriToEchoUri(uri string) string {
 // This function converts a swagger style path URI with parameters to a
 // Chi compatible path URI. We need to replace all of Swagger parameters with
 // "{param}". Valid input parameters are:
-//   {param}
-//   {param*}
-//   {.param}
-//   {.param*}
-//   {;param}
-//   {;param*}
-//   {?param}
-//   {?param*}
+//
+//	{param}
+//	{param*}
+//	{.param}
+//	{.param*}
+//	{;param}
+//	{;param*}
+//	{?param}
+//	{?param*}
 func SwaggerUriToChiUri(uri string) string {
 	return pathParamRE.ReplaceAllString(uri, "{$1}")
 }
@@ -300,14 +300,15 @@ func SwaggerUriToChiUri(uri string) string {
 // This function converts a swagger style path URI with parameters to a
 // Gin compatible path URI. We need to replace all of Swagger parameters with
 // ":param". Valid input parameters are:
-//   {param}
-//   {param*}
-//   {.param}
-//   {.param*}
-//   {;param}
-//   {;param*}
-//   {?param}
-//   {?param*}
+//
+//	{param}
+//	{param*}
+//	{.param}
+//	{.param*}
+//	{;param}
+//	{;param*}
+//	{?param}
+//	{?param*}
 func SwaggerUriToGinUri(uri string) string {
 	return pathParamRE.ReplaceAllString(uri, ":$1")
 }
@@ -611,4 +612,9 @@ func EscapePathElements(path string) string {
 		elems[i] = url.QueryEscape(e)
 	}
 	return strings.Join(elems, "/")
+}
+
+// IsMediaTypeJson checks if the media type provided falls into the json kind.
+func IsMediaTypeJson(mediaType string) bool {
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
 }

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -616,7 +616,13 @@ func EscapePathElements(path string) string {
 
 // IsMediaTypeJson checks if the media type provided falls into the json kind.
 func IsMediaTypeJson(mediaType string) bool {
-	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+	for _, contentType := range contentTypesJSON {
+		if mediaType == contentType {
+			return true
+		}
+	}
+
+	return false
 }
 
 func GetJsonMediaType(content openapi3.Content) (*openapi3.MediaType, bool) {

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -618,3 +618,13 @@ func EscapePathElements(path string) string {
 func IsMediaTypeJson(mediaType string) bool {
 	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
 }
+
+func GetJsonMediaType(content openapi3.Content) (*openapi3.MediaType, bool) {
+	for k, mediaType := range content {
+		if IsMediaTypeJson(k) {
+			return mediaType, true
+		}
+	}
+
+	return nil, false
+}


### PR DESCRIPTION
test run result: 
```
=== RUN   TestExamplePetStoreCodeGeneration
--- PASS: TestExamplePetStoreCodeGeneration (0.03s)
=== RUN   TestExamplePetStoreCodeGenerationWithUserTemplates
--- PASS: TestExamplePetStoreCodeGenerationWithUserTemplates (0.01s)
=== RUN   TestExamplePetStoreParseFunction
--- PASS: TestExamplePetStoreParseFunction (0.00s)
=== RUN   TestExampleOpenAPICodeGeneration
--- PASS: TestExampleOpenAPICodeGeneration (0.03s)
=== RUN   Test_extTypeName
=== RUN   Test_extTypeName/success
=== RUN   Test_extTypeName/type_conversion_error
=== RUN   Test_extTypeName/json_unmarshal_error
--- PASS: Test_extTypeName (0.00s)
    --- PASS: Test_extTypeName/success (0.00s)
    --- PASS: Test_extTypeName/type_conversion_error (0.00s)
    --- PASS: Test_extTypeName/json_unmarshal_error (0.00s)
=== RUN   TestFilterOperationsByTag
=== RUN   TestFilterOperationsByTag/include_tags
=== RUN   TestFilterOperationsByTag/exclude_tags
--- PASS: TestFilterOperationsByTag (0.03s)
    --- PASS: TestFilterOperationsByTag/include_tags (0.01s)
    --- PASS: TestFilterOperationsByTag/exclude_tags (0.02s)
=== RUN   TestGenerateDefaultOperationID
--- PASS: TestGenerateDefaultOperationID (0.00s)
=== RUN   TestFindReferences
=== RUN   TestFindReferences/unfiltered
=== RUN   TestFindReferences/only_cat
=== RUN   TestFindReferences/only_dog
--- PASS: TestFindReferences (0.01s)
    --- PASS: TestFindReferences/unfiltered (0.00s)
    --- PASS: TestFindReferences/only_cat (0.00s)
    --- PASS: TestFindReferences/only_dog (0.00s)
=== RUN   TestFilterOnlyCat
--- PASS: TestFilterOnlyCat (0.00s)
=== RUN   TestFilterOnlyDog
--- PASS: TestFilterOnlyDog (0.00s)
=== RUN   TestPruningUnusedComponents
--- PASS: TestPruningUnusedComponents (0.00s)
=== RUN   TestStringOps
--- PASS: TestStringOps (0.00s)
=== RUN   TestSortedSchemaKeys
--- PASS: TestSortedSchemaKeys (0.00s)
=== RUN   TestSortedPathsKeys
--- PASS: TestSortedPathsKeys (0.00s)
=== RUN   TestSortedOperationsKeys
--- PASS: TestSortedOperationsKeys (0.00s)
=== RUN   TestSortedResponsesKeys
--- PASS: TestSortedResponsesKeys (0.00s)
=== RUN   TestSortedContentKeys
--- PASS: TestSortedContentKeys (0.00s)
=== RUN   TestSortedParameterKeys
--- PASS: TestSortedParameterKeys (0.00s)
=== RUN   TestSortedRequestBodyKeys
--- PASS: TestSortedRequestBodyKeys (0.00s)
=== RUN   TestRefPathToGoType
=== RUN   TestRefPathToGoType/local-schemas
=== RUN   TestRefPathToGoType/local-parameters
=== RUN   TestRefPathToGoType/local-responses
=== RUN   TestRefPathToGoType/remote-root
=== RUN   TestRefPathToGoType/remote-pathed
=== RUN   TestRefPathToGoType/url-root
=== RUN   TestRefPathToGoType/url-pathed
=== RUN   TestRefPathToGoType/local-too-deep
=== RUN   TestRefPathToGoType/remote-too-deep
=== RUN   TestRefPathToGoType/url-too-deep
--- PASS: TestRefPathToGoType (0.00s)
    --- PASS: TestRefPathToGoType/local-schemas (0.00s)
    --- PASS: TestRefPathToGoType/local-parameters (0.00s)
    --- PASS: TestRefPathToGoType/local-responses (0.00s)
    --- PASS: TestRefPathToGoType/remote-root (0.00s)
    --- PASS: TestRefPathToGoType/remote-pathed (0.00s)
    --- PASS: TestRefPathToGoType/url-root (0.00s)
    --- PASS: TestRefPathToGoType/url-pathed (0.00s)
    --- PASS: TestRefPathToGoType/local-too-deep (0.00s)
    --- PASS: TestRefPathToGoType/remote-too-deep (0.00s)
    --- PASS: TestRefPathToGoType/url-too-deep (0.00s)
=== RUN   TestIsWholeDocumentReference
--- PASS: TestIsWholeDocumentReference (0.00s)
=== RUN   TestIsGoTypeReference
--- PASS: TestIsGoTypeReference (0.00s)
=== RUN   TestSwaggerUriToEchoUri
--- PASS: TestSwaggerUriToEchoUri (0.00s)
=== RUN   TestSwaggerUriToGinUri
--- PASS: TestSwaggerUriToGinUri (0.00s)
=== RUN   TestOrderedParamsFromUri
--- PASS: TestOrderedParamsFromUri (0.00s)
=== RUN   TestReplacePathParamsWithStr
--- PASS: TestReplacePathParamsWithStr (0.00s)
=== RUN   TestStringToGoComment
=== RUN   TestStringToGoComment/blank_string_should_be_ignored_due_to_human_unreadable
=== RUN   TestStringToGoComment/whitespace_should_be_ignored_due_to_human_unreadable
=== RUN   TestStringToGoComment/single_line_comment
=== RUN   TestStringToGoComment/single_line_comment_preserving_whitespace
=== RUN   TestStringToGoComment/multi_line_preserving_whitespaces_using_tabs_or_spaces
--- PASS: TestStringToGoComment (0.00s)
    --- PASS: TestStringToGoComment/blank_string_should_be_ignored_due_to_human_unreadable (0.00s)
    --- PASS: TestStringToGoComment/whitespace_should_be_ignored_due_to_human_unreadable (0.00s)
    --- PASS: TestStringToGoComment/single_line_comment (0.00s)
    --- PASS: TestStringToGoComment/single_line_comment_preserving_whitespace (0.00s)
    --- PASS: TestStringToGoComment/multi_line_preserving_whitespaces_using_tabs_or_spaces (0.00s)
=== RUN   TestEscapePathElements
--- PASS: TestEscapePathElements (0.00s)
PASS

```